### PR TITLE
Update default glibc version to 2.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu-debootstrap:14.04
 ENV PREFIX_DIR /usr/glibc-compat
-ENV GLIBC_VERSION 2.22
+ENV GLIBC_VERSION 2.23
 RUN apt-get -q update \
 	&& apt-get -qy install build-essential wget openssl gawk
 COPY configparams /glibc-build/configparams

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 ## Usage
 
-Build a glibc package based on version 2.21 with a prefix of `/usr/glibc-compat`:
+Build a glibc package based on version 2.23 with a prefix of `/usr/glibc-compat`:
 
 ```
-docker run --rm -e STDOUT=1 andyshinn/glibc-builder 2.21 /usr/glibc-compat > glibc-bin.tar.gz
+docker run --rm -e STDOUT=1 andyshinn/glibc-builder 2.23 /usr/glibc-compat > glibc-bin.tar.gz
 ```
 
 You can also keep the container around and copy out the resulting file:
 
 ```
-docker run --name glibc-binary andyshinn/glibc-builder 2.21 /usr/glibc-compat
-docker cp glibc-binary:/glibc-bin-2.21.tar.gz ./
+docker run --name glibc-binary andyshinn/glibc-builder 2.23 /usr/glibc-compat
+docker cp glibc-binary:/glibc-bin-2.23.tar.gz ./
 docker rm glibc-binary
 ```


### PR DESCRIPTION
This commit updates the default glibc version to 2.23 in response
to several security fixes that were released 19 FEB 2016.
Specifically [CVE-2015-7547](https://googleonlinesecurity.blogspot.com/2016/02/cve-2015-7547-glibc-getaddrinfo-stack.html).

Release notes: https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;utm_source=anzwix;h=c0276cf81b7e838becaa252c09d3900cce6cd277;hb=refs/heads/release/2.23/master
