### PR TITLE
Support compiling for multiple architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM multiarch/ubuntu-debootstrap:amd64-slim
 ENV PREFIX_DIR /usr/glibc-compat
 ENV GLIBC_VERSION 2.23
+ENV ARCH x86_64
 RUN apt-get -q update \
 	&& apt-get -qy install build-essential wget openssl gawk
 COPY configparams /glibc-build/configparams

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu-debootstrap:14.04
+FROM multiarch/ubuntu-debootstrap:amd64-slim
 ENV PREFIX_DIR /usr/glibc-compat
 ENV GLIBC_VERSION 2.23
 RUN apt-get -q update \

--- a/builder
+++ b/builder
@@ -3,7 +3,7 @@
 set -eo pipefail; [[ "$TRACE" ]] && set -x
 
 main() {
-	declare version="${1:-$GLIBC_VERSION}" prefix="${2:-$PREFIX_DIR}"
+	declare version="${1:-$GLIBC_VERSION}" prefix="${2:-$PREFIX_DIR}" arch="${3:-$ARCH}"
 
 	: "${version:?}" "${prefix:?}"
 
@@ -15,12 +15,13 @@ main() {
 			--prefix="$prefix" \
 			--libdir="$prefix/lib" \
 			--libexecdir="$prefix/lib" \
+			--host=${arch}-linux \
 			--enable-multi-arch
 		make && make install
-		tar --hard-dereference -zcf "/glibc-bin-$version.tar.gz" "$prefix"
+		tar --hard-dereference -zcf "/glibc-bin-$version-$arch.tar.gz" "$prefix"
 	} >&2
 
-	[[ $STDOUT ]] && cat "/glibc-bin-$version.tar.gz"
+	[[ $STDOUT ]] && cat "/glibc-bin-$version-$arch.tar.gz"
 }
 
 main "$@"


### PR DESCRIPTION
💁  These changes enable building glibc for host architectures which differ from the build environment's architecture. The default host architecture remains as x86_64, but any host architecture supported by glibc's `configure` can be specified.

Closes #7
