### PR TITLE
Bump glibc version to 2.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu-debootstrap:14.04
 ENV PREFIX_DIR /usr/glibc-compat
-ENV GLIBC_VERSION 2.23
+ENV GLIBC_VERSION 2.24
 RUN apt-get -q update \
 	&& apt-get -qy install build-essential wget openssl gawk
 COPY configparams /glibc-build/configparams

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 ## Usage
 
-Build a glibc package based on version 2.23 with a prefix of `/usr/glibc-compat`:
+Build a glibc package based on version 2.24 with a prefix of `/usr/glibc-compat`:
 
 ```
-docker run --rm -e STDOUT=1 andyshinn/glibc-builder 2.23 /usr/glibc-compat > glibc-bin.tar.gz
+docker run --rm -e STDOUT=1 andyshinn/glibc-builder 2.24 /usr/glibc-compat > glibc-bin.tar.gz
 ```
 
 You can also keep the container around and copy out the resulting file:
 
 ```
-docker run --name glibc-binary andyshinn/glibc-builder 2.23 /usr/glibc-compat
-docker cp glibc-binary:/glibc-bin-2.23.tar.gz ./
+docker run --name glibc-binary andyshinn/glibc-builder 2.24 /usr/glibc-compat
+docker cp glibc-binary:/glibc-bin-2.24.tar.gz ./
 docker rm glibc-binary
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ general:
     - "artifacts"
 machine:
   environment:
-    GLIBC_VERSION: 2.23
+    GLIBC_VERSION: 2.24
   services:
     - docker
 dependencies:


### PR DESCRIPTION
💁  This change updates the version of glibc to 2.24.

Upstream reference commit: https://sourceware.org/git/?p=glibc.git;a=commit;h=fdfc9260b61d3d72541f18104d24c7bcb0ce5ca2

Closes #10