### PR TITLE
Upload build artifacts to GitHub releases with CircleCI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu-debootstrap:14.04
+MAINTAINER Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>
 ENV PREFIX_DIR /usr/glibc-compat
 ENV GLIBC_VERSION 2.24
 RUN apt-get -q update \

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 Build a glibc package based on version 2.24 with a prefix of `/usr/glibc-compat`:
 
 ```
-docker run --rm -e STDOUT=1 andyshinn/glibc-builder 2.24 /usr/glibc-compat > glibc-bin.tar.gz
+docker run --rm -e STDOUT=1 sgerrand/glibc-builder 2.24 /usr/glibc-compat > glibc-bin.tar.gz
 ```
 
 You can also keep the container around and copy out the resulting file:
 
 ```
-docker run --name glibc-binary andyshinn/glibc-builder 2.24 /usr/glibc-compat
+docker run --name glibc-binary sgerrand/glibc-builder 2.24 /usr/glibc-compat
 docker cp glibc-binary:/glibc-bin-2.24.tar.gz ./
 docker rm glibc-binary
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,9 @@ machine:
   services:
     - docker
 dependencies:
+  pre:
+    - git fetch --tags
+    - go get github.com/tcnksm/ghr
   override:
     - docker pull sgerrand/glibc-builder
 test:
@@ -14,3 +17,15 @@ test:
     - mkdir -p artifacts
   override:
     - "docker run --rm -e STDOUT=1 sgerrand/glibc-builder $GLIBC_VERSION /usr/glibc-compat > artifacts/glibc-bin-$GLIBC_VERSION-$(uname -m).tar.gz"
+deployment:
+  release:
+    tag: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/
+    owner: sgerrand
+    commands:
+      - ghr -u sgerrand $CIRCLE_TAG artifacts/
+  master:
+    branch: master
+    owner: sgerrand
+    commands:
+      - ghr -u sgerrand --prerelease --delete unreleased artifacts
+      - ghr -u sgerrand --prerelease unreleased artifacts

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,10 @@ general:
 machine:
   environment:
     GLIBC_VERSION: 2.24
+  pre:
+    - sudo mv /usr/local/go /usr/local/go-1.6.2
+    - wget -q -O /tmp/go1.7.3.tgz https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz
+    - sudo tar -xzf /tmp/go1.7.3.tgz -C /usr/local
   services:
     - docker
 dependencies:


### PR DESCRIPTION
💁  These changes leverage CircleCI's deployment stage to automatically release build artifacts to GitHub.

* Commits to master will update the "unreleased" release
* New tags will create a GitHub release which matches the tag name

Closes #12 