### PR TITLE
Bump glibc version to 2.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu-debootstrap:14.04
 MAINTAINER Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>
 ENV PREFIX_DIR /usr/glibc-compat
-ENV GLIBC_VERSION 2.24
+ENV GLIBC_VERSION 2.25
 RUN apt-get -q update \
 	&& apt-get -qy install build-essential wget openssl gawk
 COPY configparams /glibc-build/configparams

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 ## Usage
 
-Build a glibc package based on version 2.24 with a prefix of `/usr/glibc-compat`:
+Build a glibc package based on version 2.25 with a prefix of `/usr/glibc-compat`:
 
 ```
-docker run --rm -e STDOUT=1 sgerrand/glibc-builder 2.24 /usr/glibc-compat > glibc-bin.tar.gz
+docker run --rm -e STDOUT=1 sgerrand/glibc-builder 2.25 /usr/glibc-compat > glibc-bin.tar.gz
 ```
 
 You can also keep the container around and copy out the resulting file:
 
 ```
-docker run --name glibc-binary sgerrand/glibc-builder 2.24 /usr/glibc-compat
-docker cp glibc-binary:/glibc-bin-2.24.tar.gz ./
+docker run --name glibc-binary sgerrand/glibc-builder 2.25 /usr/glibc-compat
+docker cp glibc-binary:/glibc-bin-2.25.tar.gz ./
 docker rm glibc-binary
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ general:
     - "artifacts"
 machine:
   environment:
-    GLIBC_VERSION: 2.24
+    GLIBC_VERSION: 2.25
   pre:
     - sudo mv /usr/local/go /usr/local/go-1.6.2
     - wget -q -O /tmp/go1.7.3.tgz https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz


### PR DESCRIPTION
💁 These changes bump the version of [`glibc`](https://www.gnu.org/software/libc/) to 2.25.