### PR TITLE
Remove duplicate artefact uploads

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ test:
     - "docker run --rm -e STDOUT=1 sgerrand/glibc-builder $GLIBC_VERSION /usr/glibc-compat > artifacts/glibc-bin-$GLIBC_VERSION-0-$(uname -m).tar.gz"
 deployment:
   release:
-    tag: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/
+    tag: /[0-9]+(\.[0-9]+){1,2}(\-\d+)?$/
     owner: sgerrand
     commands:
       - ghr -u sgerrand $CIRCLE_TAG artifacts/

--- a/circle.yml
+++ b/circle.yml
@@ -32,4 +32,3 @@ deployment:
     owner: sgerrand
     commands:
       - ghr -u sgerrand --prerelease --delete unreleased artifacts
-      - ghr -u sgerrand --prerelease unreleased artifacts

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
   pre:
     - mkdir -p artifacts
   override:
-    - "docker run --rm -e STDOUT=1 sgerrand/glibc-builder $GLIBC_VERSION /usr/glibc-compat > artifacts/glibc-bin-$GLIBC_VERSION-$(uname -m).tar.gz"
+    - "docker run --rm -e STDOUT=1 sgerrand/glibc-builder $GLIBC_VERSION /usr/glibc-compat > artifacts/glibc-bin-$GLIBC_VERSION-0-$(uname -m).tar.gz"
 deployment:
   release:
     tag: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/


### PR DESCRIPTION
💁 These changes clean up the artefact release steps so that little to no manual intervention is required.