### PR TITLE
Bump glibc to v2.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>
 ENV PREFIX_DIR /usr/glibc-compat
-ENV GLIBC_VERSION 2.27
+ENV GLIBC_VERSION 2.28
 RUN apt-get -q update \
 	&& apt-get -qy install bison build-essential wget openssl gawk
 COPY configparams /glibc-build/configparams

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 ## Usage
 
-Build a glibc package based on version 2.27 with a prefix of `/usr/glibc-compat`:
+Build a glibc package based on version 2.28 with a prefix of `/usr/glibc-compat`:
 
 ```
-docker run --rm -e STDOUT=1 sgerrand/glibc-builder 2.27 /usr/glibc-compat > glibc-bin.tar.gz
+docker run --rm -e STDOUT=1 sgerrand/glibc-builder 2.28 /usr/glibc-compat > glibc-bin.tar.gz
 ```
 
 You can also keep the container around and copy out the resulting file:
 
 ```
-docker run --name glibc-binary sgerrand/glibc-builder 2.27 /usr/glibc-compat
-docker cp glibc-binary:/glibc-bin-2.27.tar.gz ./
+docker run --name glibc-binary sgerrand/glibc-builder 2.28 /usr/glibc-compat
+docker cp glibc-binary:/glibc-bin-2.28.tar.gz ./
 docker rm glibc-binary
 ```

--- a/builder
+++ b/builder
@@ -8,7 +8,7 @@ main() {
 	: "${version:?}" "${prefix:?}"
 
 	{
-		wget -qO- "http://ftp.gnu.org/gnu/glibc/glibc-$version.tar.gz" \
+		wget -qO- "https://ftpmirror.gnu.org/libc/glibc-$version.tar.gz" \
 			| tar zxf -
 		mkdir -p /glibc-build && cd /glibc-build
 		"/glibc-$version/configure" \

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ dependencies:
     - git fetch --tags
     - go get github.com/tcnksm/ghr
   override:
-    - docker build . --tag sgerrand/glibc-builder:$CIRCLE_SHA1
+    - docker build --tag sgerrand/glibc-builder:$CIRCLE_SHA1 .
 test:
   pre:
     - mkdir -p artifacts

--- a/circle.yml
+++ b/circle.yml
@@ -15,12 +15,12 @@ dependencies:
     - git fetch --tags
     - go get github.com/tcnksm/ghr
   override:
-    - docker pull sgerrand/glibc-builder
+    - docker build . --tag sgerrand/glibc-builder:$CIRCLE_SHA1
 test:
   pre:
     - mkdir -p artifacts
   override:
-    - "docker run --rm -e STDOUT=1 sgerrand/glibc-builder $GLIBC_VERSION /usr/glibc-compat > artifacts/glibc-bin-$GLIBC_VERSION-0-$(uname -m).tar.gz"
+    - docker run --rm -e STDOUT=1 sgerrand/glibc-builder:$CIRCLE_SHA1 $GLIBC_VERSION /usr/glibc-compat > artifacts/glibc-bin-$GLIBC_VERSION-0-$(uname -m).tar.gz
 deployment:
   release:
     tag: /[0-9]+(\.[0-9]+){1,2}(\-\d+)?$/

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ general:
     - "artifacts"
 machine:
   environment:
-    GLIBC_VERSION: 2.27
+    GLIBC_VERSION: 2.28
   pre:
     - sudo mv /usr/local/go /usr/local/go-1.6.2
     - wget -q -O /tmp/go1.7.3.tgz https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz


### PR DESCRIPTION
💁 These changes bump the version of [`glibc`](https://www.gnu.org/software/libc/) to 2.28.