### PR TITLE
Enable stack smashing protector

### DIFF
--- a/builder
+++ b/builder
@@ -15,7 +15,8 @@ main() {
 			--prefix="$prefix" \
 			--libdir="$prefix/lib" \
 			--libexecdir="$prefix/lib" \
-			--enable-multi-arch
+			--enable-multi-arch \
+			--enable-stack-protector=strong
 		make && make install
 		tar --hard-dereference -zcf "/glibc-bin-$version.tar.gz" "$prefix"
 	} >&2


### PR DESCRIPTION
💁 As suggested by @asieira:
> The following is available since glibc 2.25:
>
>> * Most of glibc can now be built with the stack smashing protector enabled.
>>  It is recommended to build glibc with --enable-stack-protector=strong.
>>  Implemented by Nick Alcock (Oracle).

Closes #17.