### PR TITLE
Attach previous workspace before upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - *artefact-ghr
       - deploy:
           name: Upload to GitHub release
-          command: ghr -u sgerrand --prerelease --delete unreleased artifacts
+          command: ghr -r $CIRCLE_PROJECT_REPONAME -u $CIRCLE_PROJECT_USERNAME --prerelease --delete unreleased artifacts
   upload-tag:
     <<: *artefact-upload-job
     steps:
@@ -52,7 +52,7 @@ jobs:
       - *artefact-ghr
       - deploy:
           name: Upload to GitHub release
-          command: ghr -u sgerrand $CIRCLE_TAG artifacts/
+          command: ghr -r $CIRCLE_PROJECT_REPONAME -u $CIRCLE_PROJECT_USERNAME $CIRCLE_TAG artifacts/
 workflows:
   version: 2
   build-compile-upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ references:
     <<: *basic-job
     docker:
       - image: golang:alpine
+  artefact-attach-workspace: &artefact-attach-workspace
+    attach_workspace:
+      at: .
   artefact-packages: &artefact-packages
     run:
       command: apk add --no-cache git openssh-client
@@ -36,7 +39,7 @@ jobs:
     <<: *artefact-upload-job
     steps:
       - *artefact-packages
-      - checkout
+      - *artefact-attach-workspace
       - *artefact-ghr
       - deploy:
           name: Upload to GitHub release
@@ -45,7 +48,7 @@ jobs:
     <<: *artefact-upload-job
     steps:
       - *artefact-packages
-      - checkout
+      - *artefact-attach-workspace
       - *artefact-ghr
       - deploy:
           name: Upload to GitHub release


### PR DESCRIPTION
💁 The [`upload-master` job failed](https://circleci.com/gh/sgerrand/docker-glibc-builder/69) with the following error message:

> 
```
ghr -u sgerrand --prerelease --delete unreleased artifacts
Failed to find assets from artifacts: failed to get file stat: stat /root/docker-glibc-builder/artifacts: no such file or directory
Exited with code 11
```

There is no need to checkout code in a job which will upload the previously compiled artefacts. This was missed in the previous changes, mainly because it is complex to test workflow stages.