### PR TITLE
Install helper programs for compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,15 @@ MAINTAINER Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>
 ENV PREFIX_DIR /usr/glibc-compat
 ENV GLIBC_VERSION 2.28
 RUN apt-get -q update \
-	&& apt-get -qy install bison build-essential wget openssl gawk gettext python3 texinfo
+	&& apt-get -qy install \
+		bison \
+		build-essential \
+		gawk \
+		gettext \
+		openssl \
+		python3 \
+		texinfo \
+		wget
 COPY configparams /glibc-build/configparams
 COPY builder /builder
 ENTRYPOINT ["/builder"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>
 ENV PREFIX_DIR /usr/glibc-compat
 ENV GLIBC_VERSION 2.28
 RUN apt-get -q update \
-	&& apt-get -qy install bison build-essential wget openssl gawk
+	&& apt-get -qy install bison build-essential wget openssl gawk gettext python3 texinfo
 COPY configparams /glibc-build/configparams
 COPY builder /builder
 ENTRYPOINT ["/builder"]


### PR DESCRIPTION
💁 Prompted from the following output from `./configure`:

    checking for python3... no
    checking for python... no
    configure: WARNING:
    *** These auxiliary programs are missing or incompatible versions: msgfmt makeinfo python
    *** some features or tests will be disabled.
    *** Check the INSTALL file for required versions.