### PR TITLE
Ubuntu Bionic Beaver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>
 ENV PREFIX_DIR /usr/glibc-compat
 ENV GLIBC_VERSION 2.28


### PR DESCRIPTION
💁 Bumps the version of Ubuntu to the current latest LTS release, [18.04 the Bionic Beaver](https://wiki.ubuntu.com/BionicBeaver).

Closes #28 