### PR TITLE
Dereference symlinks

### DIFF
--- a/builder
+++ b/builder
@@ -18,7 +18,7 @@ main() {
 			--enable-multi-arch \
 			--enable-stack-protector=strong
 		make && make install
-		tar --hard-dereference -zcf "/glibc-bin-$version.tar.gz" "$prefix"
+		tar --dereference --hard-dereference -zcf "/glibc-bin-$version.tar.gz" "$prefix"
 	} >&2
 
 	[[ $STDOUT ]] && cat "/glibc-bin-$version.tar.gz"


### PR DESCRIPTION
💁 The `--dereference` flag needs to be passed to tar in order for any symlinks added to the archive to be referenced correctly. Otherwise, the following error can occur when `abuild` unpacks the tar archive:

    >>> glibc: Fetching https://github.com/sgerrand/docker-glibc-builder/releases/download/2.30-0/glibc-bin-2.30-0-x86_64.tar.gz
    >>> glibc: Checking sha512sums...
    glibc-bin-2.30-0-x86_64.tar.gz: OK
    nsswitch.conf: OK
    ld.so.conf: OK
    >>> glibc: Unpacking /var/cache/distfiles/glibc-bin-2.30-0-x86_64.tar.gz...
    tar: usr/glibc-compat/lib/libnss_compat.so.2: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libnss_dns.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libpthread.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libcrypt.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libnss_files.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libnss_db.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libmvec.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libdl.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libanl.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libthread_db.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libcrypt.so.1: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libc.so.6: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libresolv.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libutil.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libBrokenLocale.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libnss_files.so.2: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libmvec.so.1: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libdl.so.2: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libanl.so.1: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/librt.so: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libnsl.so.1: Cannot utime: No such file or directory
    tar: usr/glibc-compat/lib/libnss_db.so.2: Cannot utime: No such file or directory
    tar: Exiting with failure status due to previous errors
    >>> ERROR: glibc: unpack failed