### PR TITLE
glibc 2.31

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
     docker:
       - image: docker:git
     environment:
-      GLIBC_VERSION: 2.30
+      GLIBC_VERSION: 2.31
     working_directory: ~/docker-glibc-builder
   artefact-uploader:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:19.04
 MAINTAINER Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>
 ENV PREFIX_DIR /usr/glibc-compat
-ENV GLIBC_VERSION 2.30
+ENV GLIBC_VERSION 2.31
 RUN apt-get -q update \
 	&& apt-get -qy install \
 		bison \

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 ## Usage
 
-Build a glibc package based on version 2.30 with a prefix of `/usr/glibc-compat`:
+Build a glibc package based on version 2.31 with a prefix of `/usr/glibc-compat`:
 
-    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.30 /usr/glibc-compat > glibc-bin.tar.gz
+    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.31 /usr/glibc-compat > glibc-bin.tar.gz
 
 You can also keep the container around and copy out the resulting file:
 
-    docker run --name glibc-binary sgerrand/glibc-builder 2.30 /usr/glibc-compat
-    docker cp glibc-binary:/glibc-bin-2.30.tar.gz ./
+    docker run --name glibc-binary sgerrand/glibc-builder 2.31 /usr/glibc-compat
+    docker cp glibc-binary:/glibc-bin-2.31.tar.gz ./
     docker rm glibc-binary


### PR DESCRIPTION
💁 The GNU C Library [version 2.31 was released](https://sourceware.org/ml/libc-announce/2020/msg00001.html) on 1 Feb 2020.