### PR TITLE
glibc v2.32

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
     docker:
       - image: docker:git
     environment:
-      GLIBC_VERSION: 2.31
+      GLIBC_VERSION: 2.32
     working_directory: ~/docker-glibc-builder
   artefact-uploader:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>"
 ENV DEBIAN_FRONTEND=noninteractive \
-    GLIBC_VERSION=2.31 \
+    GLIBC_VERSION=2.32 \
     PREFIX_DIR=/usr/glibc-compat
 RUN apt-get -q update \
 	&& apt-get -qy install \

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 ## Usage
 
-Build a glibc package based on version 2.31 with a prefix of `/usr/glibc-compat`:
+Build a glibc package based on version 2.32 with a prefix of `/usr/glibc-compat`:
 
-    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.31 /usr/glibc-compat > glibc-bin.tar.gz
+    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.32 /usr/glibc-compat > glibc-bin.tar.gz
 
 You can also keep the container around and copy out the resulting file:
 
-    docker run --name glibc-binary sgerrand/glibc-builder 2.31 /usr/glibc-compat
-    docker cp glibc-binary:/glibc-bin-2.31.tar.gz ./
+    docker run --name glibc-binary sgerrand/glibc-builder 2.32 /usr/glibc-compat
+    docker cp glibc-binary:/glibc-bin-2.32.tar.gz ./
     docker rm glibc-binary


### PR DESCRIPTION
💁 Updates the version of the GNU C Library to version 2.32. ~The CI build will be fixed once the [upstream package](http://www.gnu.org/software/libc/) is released in August 2020.~

The GNU C Library maintainers released version 2.32 on 3 August 2020.

https://sourceware.org/pipermail/libc-announce/2020/000029.html