### PR TITLE
Enable Arm64 images by docker buildx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ jobs:
           command: mkdir -p artefacts
           name: Create directory for storing artefacts
       - run:
-          command: docker build . --tag sgerrand/glibc-builder:$CIRCLE_SHA1
-          name: Create Docker image
+          command: ./build.sh
+          name: Create Multi-arch Docker images
       - run:
-          command: docker run --rm --env GLIBC_VERSION --env STDOUT=1 sgerrand/glibc-builder:$CIRCLE_SHA1 > artefacts/glibc-bin-$GLIBC_VERSION-0-$(uname -m).tar.gz
+          command: ./buildpackage.sh
           name: Build glibc package
       - persist_to_workspace:
           root: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,20 @@
-FROM ubuntu:20.04
+#Add qemu function for supporting multiarch
+ARG IMAGEARCH
+FROM alpine:3.12 as qemu
+RUN apk add --no-cache curl
+ARG QEMUVERSION=4.0.0
+ARG QEMUARCH
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMUVERSION}/qemu-${QEMUARCH}-static.tar.gz | tar zxvf - -C /usr/bin
+RUN chmod +x /usr/bin/qemu-*
+
+FROM ${IMAGEARCH}ubuntu:20.04
 LABEL maintainer="Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>"
+ARG QEMUARCH
+COPY --from=qemu /usr/bin/qemu-${QEMUARCH}-static /usr/bin/
+
 ENV DEBIAN_FRONTEND=noninteractive \
     GLIBC_VERSION=2.31 \
     PREFIX_DIR=/usr/glibc-compat

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Build docker script
+set -e
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+# Build x86 images
+docker build --build-arg IMAGEARCH= \
+                   --build-arg QEMUARCH="x86_64" \
+                   --file Dockerfile --tag sgerrand/glibc-builder:"$CIRCLE_SHA1"-amd64 .
+# Build arm64 image
+docker build --build-arg IMAGEARCH="arm64v8/" \
+                   --build-arg QEMUARCH="aarch64" \
+                   --file Dockerfile --tag sgerrand/glibc-builder:"$CIRCLE_SHA1"-arm64 .

--- a/buildpackage.sh
+++ b/buildpackage.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Build binary script
+set -e
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+docker run --rm --privileged multiarch/qemu-user-static --reset
+
+# Build x86 package
+docker run --rm --env GLIBC_VERSION --env STDOUT=1 sgerrand/glibc-builder:$CIRCLE_SHA1-amd64 > artefacts/glibc-bin-$GLIBC_VERSION-0-x86_64.tar.gz
+
+# Build arm64 package
+docker run --rm --env GLIBC_VERSION --env STDOUT=1 sgerrand/glibc-builder:$CIRCLE_SHA1-arm64 > artefacts/glibc-bin-$GLIBC_VERSION-0-aarch64.tar.gz


### PR DESCRIPTION
In this patch, it enables the arm64 images by docker buildx tools.
Firstly, it adds a build scripts which used for building multi-arch
images.
Secondly, modify the circle script file for building multi-arch images.

Signed-off-by: Jingzhao Ni <Jingzhao.Ni@arm.com>