### PR TITLE
Added ability to pass additional parameters for GLIBC configure script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:20.04
 LABEL maintainer="Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>"
 ENV DEBIAN_FRONTEND=noninteractive \
     GLIBC_VERSION=2.31 \
-    PREFIX_DIR=/usr/glibc-compat
+    PREFIX_DIR=/usr/glibc-compat \
+    ADD_CONF=-v
 RUN apt-get -q update \
 	&& apt-get -qy install \
 		bison \

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 Build a glibc package based on version 2.31 with a prefix of `/usr/glibc-compat`:
 
-    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.31 /usr/glibc-compat > glibc-bin.tar.gz
+    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.31 /usr/glibc-compat [Configuration additional parameters] > glibc-bin.tar.gz
 
 You can also keep the container around and copy out the resulting file:
 
-    docker run --name glibc-binary sgerrand/glibc-builder 2.31 /usr/glibc-compat
+    docker run --name glibc-binary sgerrand/glibc-builder 2.31 /usr/glibc-compat [Configuration additional parameters]
     docker cp glibc-binary:/glibc-bin-2.31.tar.gz ./
     docker rm glibc-binary

--- a/builder
+++ b/builder
@@ -3,9 +3,9 @@
 set -eo pipefail; [[ "$TRACE" ]] && set -x
 
 main() {
-	declare version="${1:-$GLIBC_VERSION}" prefix="${2:-$PREFIX_DIR}"
+	declare version="${1:-$GLIBC_VERSION}" prefix="${2:-$PREFIX_DIR}" addconf="${3:-$ADD_CONF}"
 
-	: "${version:?}" "${prefix:?}"
+	: "${version:?}" "${prefix:?}" "${addconf:?}"
 
 	{
 		wget -qO- "https://ftpmirror.gnu.org/libc/glibc-$version.tar.gz" \
@@ -16,7 +16,7 @@ main() {
 			--libdir="$prefix/lib" \
 			--libexecdir="$prefix/lib" \
 			--enable-multi-arch \
-			--enable-stack-protector=strong
+			--enable-stack-protector=strong $addconf
 		make && make install
 		tar --dereference --hard-dereference -zcf "/glibc-bin-$version.tar.gz" "$prefix"
 	} >&2


### PR DESCRIPTION
Hi
I tried use your docker image for building glibc 2.29 and got error, in google I found for passing error I should pass into configure --enable-cet parameters so I added ability to pass additional parameters for configure into builder script.

I hope it'll be useful for other users this docker image too.

Best regards
Aleksey Kislitsa