### PR TITLE
Release Glibc for ARM64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,38 @@ jobs:
           paths: artefacts
       - store_artifacts:
           path: artefacts
+  build-arm64:
+    executor: builder
+    working_directory: ~/docker-glibc-builder
+    steps:
+       - checkout
+       - attach_workspace:
+           at: ~/docker-glibc-builder
+       - setup_remote_docker
+       - run:
+          command: mkdir -p artefacts
+          name: Create directory for storing artefacts
+       - run:
+           name: Activate QEMU
+           command:
+             docker run -it --rm --privileged multiarch/qemu-user-static  --reset --credential yes --persistent yes
+       - run:
+           name: Build Glibc for ARM64
+           no_output_timeout: 30m
+           command: |
+             docker build -t odidev/glibc-builder:$CIRCLE_SHA1 -f Dockerfile.aarch64  .
+             docker run --rm --env GLIBC_VERSION --env STDOUT=1 odidev/glibc-builder:$CIRCLE_SHA1 >  artefacts/glibc-bin-$GLIBC_VERSION-0-aarch64.tar.gz
+       - persist_to_workspace:
+           root: .
+           paths: artefacts
+       - store_artifacts:
+           path: artefacts
+       - persist_to_workspace:
+           root: .
+           paths: artefacts
+       - store_artifacts:
+           path: artefacts
+
   upload-master:
     executor: artefact-uploader
     steps:
@@ -56,3 +88,15 @@ workflows:
               ignore: /.*/
           requires:
             - build
+
+  build-arm64-compile-upload:
+    jobs:
+      - build-arm64
+      - upload-master:
+          filters:
+            branches:
+              only: master
+            tags:
+              ignore: /.*/
+          requires:
+            - build-arm64

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,18 @@
+FROM arm64v8/ubuntu:20.04
+LABEL maintainer="Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>"
+ENV DEBIAN_FRONTEND=noninteractive \
+    GLIBC_VERSION=2.32 \
+    PREFIX_DIR=/usr/glibc-compat
+RUN apt-get -q update \
+	&& apt-get -qy install \
+		bison \
+		build-essential \
+		gawk \
+		gettext \
+		openssl \
+		python3 \
+		texinfo \
+		wget
+COPY configparams /glibc-build/configparams
+COPY builder /builder
+ENTRYPOINT ["/builder"]

--- a/builder
+++ b/builder
@@ -17,7 +17,7 @@ main() {
 			--libexecdir="$prefix/lib" \
 			--enable-multi-arch \
 			--enable-stack-protector=strong
-		make && make install
+		make -j 4 && make install
 		tar --dereference --hard-dereference -zcf "/glibc-bin-$version.tar.gz" "$prefix"
 	} >&2
 


### PR DESCRIPTION
I had gone through this [PR ](https://github.com/sgerrand/docker-glibc-builder/pull/7)and found that the latest Dockerfile has the support for arm64.

I have made the changes in following files to add the support for releasing ARM64 binaries:

**.circleci/config.yml :** Added the support of building the package for arm64
**builder:** Updated the command "make" to "make -j 4" to reduce the time for building the package
**Dockerfile.aarch64:** Created a new Dockerfile for aarch64 to generate the arm64 images.


Signed-off-by: odidev <odidev@puresoftware.com>