### PR TITLE
GNU libc v2.36

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
     docker:
       - image: docker:git
     environment:
-      GLIBC_VERSION: 2.35
+      GLIBC_VERSION: 2.36
     working_directory: ~/docker-glibc-builder
   artefact-uploader:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>"
 ENV DEBIAN_FRONTEND=noninteractive \
-    GLIBC_VERSION=2.35 \
+    GLIBC_VERSION=2.36 \
     PREFIX_DIR=/usr/glibc-compat
 RUN apt-get -q update \
 	&& apt-get -qy install \

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 ## Usage
 
-Build a glibc package based on version 2.35 with a prefix of `/usr/glibc-compat`:
+Build a glibc package based on version 2.36 with a prefix of `/usr/glibc-compat`:
 
-    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.35 /usr/glibc-compat > glibc-bin.tar.gz
+    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.36 /usr/glibc-compat > glibc-bin.tar.gz
 
 You can also keep the container around and copy out the resulting file:
 
-    docker run --name glibc-binary sgerrand/glibc-builder 2.35 /usr/glibc-compat
-    docker cp glibc-binary:/glibc-bin-2.35.tar.gz ./
+    docker run --name glibc-binary sgerrand/glibc-builder 2.36 /usr/glibc-compat
+    docker cp glibc-binary:/glibc-bin-2.36.tar.gz ./
     docker rm glibc-binary


### PR DESCRIPTION
💁 Updates the version of the GNU C Library to version 2.36.

The GNU C Library maintainers released version 2.36 on 2 August 2022.

📖 https://sourceware.org/pipermail/libc-alpha/2022-August/141193.html

Closes #47 