### PR TITLE
CI: Rename trunk branch reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           paths: artefacts
       - store_artifacts:
           path: artefacts
-  upload-master:
+  upload-main:
     executor: artefact-uploader
     steps:
       - run:
@@ -48,10 +48,10 @@ workflows:
   build-compile-upload:
     jobs:
       - build
-      - upload-master:
+      - upload-main:
           filters:
             branches:
-              only: master
+              only: main
             tags:
               ignore: /.*/
           requires:


### PR DESCRIPTION
💁 These changes update the name of the trunk branch for this repository in the CircleCI build configuration. The name of this branch was changed some time ago but unfortunately this was not updated in lock-step then.