### PR TITLE
Prefer `go install` for modern Go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          command: go get github.com/tcnksm/ghr
+          command: go install github.com/tcnksm/ghr@latest
           name: Install ghr executable
       - deploy:
           name: Upload to GitHub release


### PR DESCRIPTION
💁 The `go get` command was deprecated in Go v1.17 and is now reserved for use in modules. These changes update the method used to install `ghr` accordingly.

```
$ go get github.com/tcnksm/ghr
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.

Exited with code exit status 1
```