### PR TITLE
CI: Update deprecated deploy step in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run:
           command: go install github.com/tcnksm/ghr@latest
           name: Install ghr executable
-      - deploy:
+      - run:
           name: Upload to GitHub release
           command: ghr -r $CIRCLE_PROJECT_REPONAME -u $CIRCLE_PROJECT_USERNAME --prerelease --delete unreleased artefacts
 workflows:


### PR DESCRIPTION
💁 This change alters the CircleCI configuration to update the deprecated `deploy` step, as flagged by the following warning emitted by CircleCI's platform:

> This job is using a deprecated deploy step, please update .circleci/config.yml to use a run step

As per: https://circleci.com/docs/migrate-from-deploy-to-run/