### PR TITLE
Parallel `make` recipes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,12 @@ executors:
       - image: docker:git
     environment:
       GLIBC_VERSION: 2.39
+    resource_class: large
     working_directory: ~/docker-glibc-builder
   artefact-uploader:
     docker:
       - image: golang:alpine
+    resource_class: small
     working_directory: ~/docker-glibc-builder
 jobs:
   build:

--- a/builder
+++ b/builder
@@ -17,7 +17,7 @@ main() {
 			--libexecdir="$prefix/lib" \
 			--enable-multi-arch \
 			--enable-stack-protector=strong
-		make && make install
+		make --jobs=4 && make install
 		tar --dereference --hard-dereference -zcf "/glibc-bin-$version.tar.gz" "$prefix"
 	} >&2
 


### PR DESCRIPTION
💁 As originally suggested by @odidev in #42, GNU make supports running multiple "jobs" or "recipes" simultaneously, which should speed up the compilation stage. Modern computers should have at least 4 CPUs (virtual or otherwise) available so that seems like a sensible default.

See: https://www.gnu.org/software/make/manual/html_node/Parallel.html