### PR TITLE
Update parent Ubuntu image from 22.04 to 24.04, to allow building glibc 2.42 or later

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,14 +22,14 @@ executors:
     docker:
       - image: docker:git
     environment:
-      GLIBC_VERSION: 2.39
+      GLIBC_VERSION: 2.42
     resource_class: arm.large
     working_directory: ~/docker-glibc-builder
   builder-x86:
     docker:
       - image: docker:git
     environment:
-      GLIBC_VERSION: 2.39
+      GLIBC_VERSION: 2.42
     resource_class: large
     working_directory: ~/docker-glibc-builder
   artefact-uploader:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL maintainer="Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>"
 ENV DEBIAN_FRONTEND=noninteractive \
     GLIBC_VERSION=2.39 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 LABEL maintainer="Sasha Gerrand <github+docker-glibc-builder@sgerrand.com>"
 ENV DEBIAN_FRONTEND=noninteractive \
-    GLIBC_VERSION=2.39 \
+    GLIBC_VERSION=2.42 \
     PREFIX_DIR=/usr/glibc-compat
 RUN apt-get -q update \
 	&& apt-get -qy install \

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A glibc binary package builder in Docker. Produces a glibc binary package that c
 
 ## Usage
 
-Build a glibc package based on version 2.39 with a prefix of `/usr/glibc-compat`:
+Build a glibc package based on version 2.42 with a prefix of `/usr/glibc-compat`:
 
-    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.39 /usr/glibc-compat > glibc-bin.tar.gz
+    docker run --rm --env STDOUT=1 sgerrand/glibc-builder 2.42 /usr/glibc-compat > glibc-bin.tar.gz
 
 You can also keep the container around and copy out the resulting file:
 
-    docker run --name glibc-binary sgerrand/glibc-builder 2.39 /usr/glibc-compat
-    docker cp glibc-binary:/glibc-bin-2.39.tar.gz ./
+    docker run --name glibc-binary sgerrand/glibc-builder 2.42 /usr/glibc-compat
+    docker cp glibc-binary:/glibc-bin-2.42.tar.gz ./
     docker rm glibc-binary


### PR DESCRIPTION
Closes #63.